### PR TITLE
Fix git source install using custom path

### DIFF
--- a/lib/batali/origin/git.rb
+++ b/lib/batali/origin/git.rb
@@ -14,7 +14,8 @@ module Batali
         super
         self.identifier = Smash.new(
           :url => url,
-          :ref => ref
+          :ref => ref,
+          :subdirectory => subdirectory
         ).checksum
         unless(name?)
           self.name = self.identifier

--- a/lib/batali/source/git.rb
+++ b/lib/batali/source/git.rb
@@ -11,14 +11,17 @@ module Batali
       include Bogo::Memoization
       include Batali::Git
 
-      attribute :subdirectory, String
+      attribute :subdirectory, String, :equivalent => true
       attribute :path, String
 
       # @return [String] directory containing contents
       def asset
         clone_repository
+        clone_path = ref_dup
         self.path = File.join(*[ref_dup, subdirectory].compact)
-        super
+        result = super
+        self.path = clone_path
+        result
       end
 
       # Overload to remove non-relevant attributes
@@ -27,7 +30,8 @@ module Batali
           Smash.new(
             :url => url,
             :ref => ref,
-            :type => self.class.name
+            :type => self.class.name,
+            :subdirectory => subdirectory
           ), *args
         )
       end


### PR DESCRIPTION
This fixes the issue raised in #54 where a git source with a custom path
defined does not properly install the subdirectory contents.