### PR TITLE
Bump grimoire constraint to provide pruning error

### DIFF
--- a/batali.gemspec
+++ b/batali.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.license = 'Apache 2.0'
   s.add_runtime_dependency 'attribute_struct', '~> 0.2.14'
-  s.add_runtime_dependency 'grimoire', '~> 0.2.8'
+  s.add_runtime_dependency 'grimoire', '~> 0.2.12'
   s.add_runtime_dependency 'bogo', '~> 0.1.20'
   s.add_runtime_dependency 'bogo-cli', '~> 0.1.23'
   s.add_runtime_dependency 'bogo-config', '~> 0.1.10'


### PR DESCRIPTION
Bumping the minimum version on the constraint will pull in updated
pruning behavior that validates newly generated world units with
requirements defined for the solver and forces error state if any
requirements do not have units.