### PR TITLE
Install cookbooks concurrently.

### DIFF
--- a/lib/batali/command/install.rb
+++ b/lib/batali/command/install.rb
@@ -20,7 +20,9 @@ module Batali
             ui.error 'No cookbooks defined within manifest! Try resolving first. (`batali resolve`)'
           else
             run_action('Installing cookbooks') do
+              threads = []
               manifest.cookbook.each do |unit|
+                threads << Thread.new do
                 if(unit.source.respond_to?(:cache_path))
                   unit.source.cache_path = cache_directory(
                     Bogo::Utility.snake(unit.source.class.name.split('::').last)
@@ -39,7 +41,9 @@ module Batali
                 ensure
                   unit.source.clean_asset(asset_path)
                 end
+               end
               end
+              threads.each { |t| t.join }
               nil
             end
           end


### PR DESCRIPTION
Hi, I'd like to make batali execution more faster. I tried to the installation of the cookbook concurrently.

Here is an sample `Batali` file.

```
Batali.define do
  source 'https://supermarket.chef.io'
  cookbook 'apt'
  cookbook 'nginx'
  cookbook 'git'
end
```

And run `batali resolv`.

Case: install cookbooks without Threads.

```
$ time ./bin/batali install
[Batali]: Readying installation destination... complete!
[Batali]: Installing cookbooks... complete!

real	0m23.691s
user	0m0.930s
sys	0m0.321s
```

Case: install cookbooks with Threads.

```
$ time ./bin/batali install
[Batali]: Readying installation destination... complete!
[Batali]: Installing cookbooks... complete!

real	0m3.301s
user	0m1.013s
sys	0m0.314s
```