### PR TITLE
Parse JSON metadata properly

### DIFF
--- a/lib/batali/origin/path.rb
+++ b/lib/batali/origin/path.rb
@@ -76,7 +76,7 @@ module Batali
       def load_metadata
         memoize(:metadata) do
           if(File.exist?(json = File.join(path, 'metadata.json')))
-            MultiJson.load(json).to_smash
+            MultiJson.load(File.read(json)).to_smash
           elsif(File.exist?(rb = File.join(path, 'metadata.rb')))
             struct = Metadata.new
             struct.set_state!(:value_collapse => true)

--- a/lib/batali/version.rb
+++ b/lib/batali/version.rb
@@ -1,5 +1,5 @@
 # Batali namespace
 module Batali
   # Current version
-  VERSION = Gem::Version.new('0.4.10')
+  VERSION = Gem::Version.new('0.4.11')
 end


### PR DESCRIPTION
Right now, we mistakenly try to parse the filename (metadata.json) /as/ json instead of reading it- this is a quick fix for that :)