### PR TITLE
Update git.rb

### DIFF
--- a/lib/batali/origin/git.rb
+++ b/lib/batali/origin/git.rb
@@ -39,7 +39,7 @@ module Batali
       def load_metadata
         fetch_repo
         original_path = path.dup
-        self.path = Utility.path_join(*[path, subdirectory].compact)
+        self.path = Utility.join_path(*[path, subdirectory].compact)
         result = super
         self.path = original_path
         result


### PR DESCRIPTION
Encountering error
`[repos/chef-veda]-> batali resolve -I -D -d
[Batali]: Loading sources... [DEBUG]: Cache directory to persist cookbooks: /Users/sam.tindell/.batali/cache
[DEBUG]: Starting cookbook auto-discovery
[DEBUG]: Completed cookbook auto-discovery
[DEBUG]: Cache directory to persist cookbooks: /Users/sam.tindell/.batali/cache
error!
[ERROR]: Reason - undefined method `path_join' for Batali::Utility:Class
ERROR: NoMethodError: undefined method `path_join' for Batali::Utility:Class`

Need to fix this method name.