### PR TITLE
Add simple synchronization helper to source. Use during install.

### DIFF
--- a/lib/batali/command/install.rb
+++ b/lib/batali/command/install.rb
@@ -24,6 +24,7 @@ module Batali
                 units_slice.map do |unit|
                   Thread.new do
                     ui.debug "Starting unit install for: #{unit.name}<#{unit.version}>"
+                    ui.debug "Unit source: #{unit.source.inspect}"
                     unit.source.synchronize do
                       if unit.source.respond_to?(:cache_path)
                         unit.source.cache_path = cache_directory(

--- a/lib/batali/command/install.rb
+++ b/lib/batali/command/install.rb
@@ -24,27 +24,29 @@ module Batali
                 units_slice.map do |unit|
                   Thread.new do
                     ui.debug "Starting unit install for: #{unit.name}<#{unit.version}>"
-                    if unit.source.respond_to?(:cache_path)
-                      unit.source.cache_path = cache_directory(
-                        Bogo::Utility.snake(unit.source.class.name.split("::").last)
-                      )
-                    end
-                    asset_path = unit.source.asset
-                    final_path = Utility.join_path(install_path, unit.name)
-                    if infrastructure?
-                      final_path << "-#{unit.version}"
-                    end
-                    begin
-                      FileUtils.cp_r(
-                        Utility.join_path(asset_path, "."),
-                        final_path
-                      )
-                      ui.debug "Completed unit install for: #{unit.name}<#{unit.version}>"
-                    rescue => e
-                      ui.debug "Failed unit install for: #{unit.name}<#{unit.version}> - #{e.class}: #{e}"
-                      raise
-                    ensure
-                      unit.source.clean_asset(asset_path)
+                    unit.source.synchronize do
+                      if unit.source.respond_to?(:cache_path)
+                        unit.source.cache_path = cache_directory(
+                          Bogo::Utility.snake(unit.source.class.name.split("::").last)
+                        )
+                      end
+                      asset_path = unit.source.asset
+                      final_path = Utility.join_path(install_path, unit.name)
+                      if infrastructure?
+                        final_path << "-#{unit.version}"
+                      end
+                      begin
+                        FileUtils.cp_r(
+                          Utility.join_path(asset_path, "."),
+                          final_path
+                        )
+                        ui.debug "Completed unit install for: #{unit.name}<#{unit.version}>"
+                      rescue => e
+                        ui.debug "Failed unit install for: #{unit.name}<#{unit.version}> - #{e.class}: #{e}"
+                        raise
+                      ensure
+                        unit.source.clean_asset(asset_path)
+                      end
                     end
                   end
                 end.map(&:join)

--- a/lib/batali/git.rb
+++ b/lib/batali/git.rb
@@ -49,6 +49,24 @@ module Batali
       klass.class_eval do
         attribute :url, String, :required => true, :equivalent => true
         attribute :ref, String, :required => true, :equivalent => true
+
+        @@locks = {}
+        @@lock_init = Mutex.new
+
+        def self.path_lock(path)
+          @@lock_init.synchronize do
+            if !@@locks[path]
+              @@locks[path] = Mutex.new
+            end
+          end
+          if block_given?
+            @@locks[path].synchronize do
+              yield
+            end
+          else
+            @@locks[path]
+          end
+        end
       end
     end
   end

--- a/lib/batali/source.rb
+++ b/lib/batali/source.rb
@@ -14,7 +14,6 @@ module Batali
     attribute :type, String, :required => true, :default => lambda { self.name } # rubocop:disable Style/RedundantSelf
 
     def initialize(args = {})
-      @lock = Mutex.new
       @cache_path = Utility.clean_path(args.delete(:cache_path))
       super
     end
@@ -24,9 +23,7 @@ module Batali
     # @yield Block to be executed
     # @return [Object]
     def synchronize
-      @lock.synchronize do
-        yield
-      end
+      yield
     end
 
     # @return [String]

--- a/lib/batali/source.rb
+++ b/lib/batali/source.rb
@@ -14,8 +14,19 @@ module Batali
     attribute :type, String, :required => true, :default => lambda { self.name } # rubocop:disable Style/RedundantSelf
 
     def initialize(args = {})
+      @lock = Mutex.new
       @cache_path = Utility.clean_path(args.delete(:cache_path))
       super
+    end
+
+    # Helper to synchronize access to this source.
+    #
+    # @yield Block to be executed
+    # @return [Object]
+    def synchronize
+      @lock.synchronize do
+        yield
+      end
     end
 
     # @return [String]

--- a/lib/batali/source/git.rb
+++ b/lib/batali/source/git.rb
@@ -19,6 +19,12 @@ module Batali
         self.path = Utility.clean_path(path)
       end
 
+      def synchronize
+        self.class.path_lock(path) do
+          yield
+        end
+      end
+
       # @return [String] directory containing contents
       def asset
         clone_repository

--- a/lib/batali/utility.rb
+++ b/lib/batali/utility.rb
@@ -11,11 +11,12 @@ module Batali
     # on platform in use
     def self.clean_path(path)
       if RUBY_PLATFORM =~ /mswin|mingw|windows/ &&
-         ENV["BATALI_DISABLE_UNC"].nil?
-        if !path.to_s.match(/^[A-Za-z]:/) && !path.start_with?(UNC_PREFIX)
+         ENV["BATALI_DISABLE_UNC"].nil? &&
+         path
+        if !path.to_s.match(/^[A-Za-z]:/) && !path.to_s.start_with?(UNC_PREFIX)
           path = File.expand_path(path.to_s)
         end
-        path = UNC_PREFIX + path unless path.start_with?(UNC_PREFIX)
+        path = UNC_PREFIX + path.to_s unless path.to_s.start_with?(UNC_PREFIX)
       end
       path
     end

--- a/lib/batali/utility.rb
+++ b/lib/batali/utility.rb
@@ -12,10 +12,10 @@ module Batali
     def self.clean_path(path)
       if RUBY_PLATFORM =~ /mswin|mingw|windows/ &&
          ENV["BATALI_DISABLE_UNC"].nil?
-        if !path.to_s.match(/^[A-Za-z]:/) && !path.start_with?(UNC_PATH)
+        if !path.to_s.match(/^[A-Za-z]:/) && !path.start_with?(UNC_PREFIX)
           path = File.expand_path(path.to_s)
         end
-        path = UNC_PREFIX + path unless path.start_with?(UNC_PATH)
+        path = UNC_PREFIX + path unless path.start_with?(UNC_PREFIX)
       end
       path
     end


### PR DESCRIPTION
When installing cookbooks using infrastructure mode and the same
git source is being used for different refs, a race condition
can occur where the cached respository is modified while a copy
is in progress. To prevent this the source should be locked
during install to prevent any unexpected modifications.

Fixes #104